### PR TITLE
Inaccessible Registry Keys Throw Unhandled SecurityException

### DIFF
--- a/Native/IShellIconOverlayIdentifier.cs
+++ b/Native/IShellIconOverlayIdentifier.cs
@@ -105,6 +105,8 @@ namespace OneDrive.Native {
         static public uint GetStateBySyncRootId(string SyncRootId, out OneDriveState State) {
             State = new OneDriveState();
             uint hr;
+            if (SyncRootId is null)
+                return 1;
             if (Marshal.SizeOf(IntPtr.Zero) == 8)
                 hr = GetStatusByTypeApi(SyncRootId, ref State);
             else

--- a/OdSyncService/OdSyncStatusWS.cs
+++ b/OdSyncService/OdSyncStatusWS.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Security.Principal;
 using System.DirectoryServices.AccountManagement;
 using OneDrive.Native;
 using OneDrive.Logging;
+using System.Security;
 
 #nullable enable
 namespace OneDrive.OdSyncService {
@@ -13,7 +14,9 @@ namespace OneDrive.OdSyncService {
         internal static bool OnDemandOnly { get; set; } = false;
         private static string UserSID {
             get {
-                userSID ??= WindowsIdentity.GetCurrent().User.ToString();
+                if (userSID is null) {
+                    userSID = WindowsIdentity.GetCurrent().User.ToString();
+                }
                 return userSID;
             }
         }
@@ -43,78 +46,88 @@ namespace OneDrive.OdSyncService {
 
         public IEnumerable<StatusDetail> GetStatusInternal() {
             const string subkeyString = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\";
-            using RegistryKey key = Registry.LocalMachine.OpenSubKey(subkeyString);
-            if (key is null) {
-                yield return new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown };
-            } else {
-                if (key.SubKeyCount == 0) {
-                    yield return new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown, ServiceType = "OneDrive" };
-                }
-                foreach (string subkey in key.GetSubKeyNames()) {
-                    RegistryKey displayKey = key.OpenSubKey(subkey);
-                    string? displayName = displayKey.GetValue("DisplayNameResource") as string;
-                    using RegistryKey userKey = key.OpenSubKey(String.Format("{0}{1}", subkey, @"\UserSyncRoots"));
-                    if (userKey != null && userKey.Name.Contains(UserSID)) {
-                        foreach (string valueName in userKey.GetValueNames()) {
-                            StatusDetail detail = new StatusDetail();
-                            try {
-                                SecurityIdentifier id = new SecurityIdentifier(valueName);
-                                //string userName = id.Translate(typeof(NTAccount)).Value;
-                                detail.UserName = id.Translate(typeof(NTAccount)).Value;
-                                detail.UserSID = valueName;
-                                detail.DisplayName = displayName;
-                                detail.SyncRootId = subkey;
+            StatusDetail detail = new StatusDetail();
+            using (RegistryKey key = Registry.LocalMachine.OpenSubKey(subkeyString)) {
+                if (key is null) {
+                    yield return new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown };
+                } else {
+                    if (key.SubKeyCount == 0) {
+                        yield return new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown, ServiceType = "OneDrive" };
+                    }
+                    foreach (string subkey in key.GetSubKeyNames()) {
+                        try {
+                            detail = new StatusDetail();
+                            RegistryKey displayKey = key.OpenSubKey(subkey);
+                            string? displayName = displayKey.GetValue("DisplayNameResource") as string;
+                            using (RegistryKey userKey = key.OpenSubKey(String.Format("{0}{1}", subkey, @"\UserSyncRoots"))) {
+                                if (userKey != null && userKey.Name.Contains(UserSID)) {
+                                    foreach (string valueName in userKey.GetValueNames()) {
+                                        detail = new StatusDetail();
+                                        try {
+                                            SecurityIdentifier id = new SecurityIdentifier(valueName);
+                                            //string userName = id.Translate(typeof(NTAccount)).Value;
+                                            detail.UserName = id.Translate(typeof(NTAccount)).Value;
+                                            detail.UserSID = valueName;
+                                            detail.DisplayName = displayName;
+                                            detail.SyncRootId = subkey;
 
-                                string[] parts = userKey.Name.Split('!');
+                                            string[] parts = userKey.Name.Split('!');
 
-                                if (parts.Length > 1) {
-                                    detail.ServiceType = parts[Math.Min(2, parts.Length - 1)].Split('|')[0];
-                                } else {
-                                    detail.ServiceType = "INVALID";
+                                            if (parts.Length > 1) {
+                                                detail.ServiceType = parts[Math.Min(2, parts.Length - 1)].Split('|')[0];
+                                            } else {
+                                                detail.ServiceType = "INVALID";
+                                            }
+                                        } catch (Exception ex) {
+                                            detail.UserName = String.Format("{0}: {1}", ex.GetType().ToString(), ex.Message);
+                                            WriteLog.WriteErrorEvent("OneDrive " + detail.UserName);
+                                        }
+                                        detail.LocalPath = userKey.GetValue(valueName) as string;
+                                        detail.StatusString = GetStatus(detail.LocalPath!).ToString();
+                                    }
                                 }
-                            } catch (Exception ex) {
-                                detail.UserName = String.Format("{0}: {1}", ex.GetType().ToString(), ex.Message);
-                                WriteLog.WriteErrorEvent("OneDrive " + detail.UserName);
                             }
-                            detail.LocalPath = userKey.GetValue(valueName) as string;
-                            detail.StatusString = GetStatus(detail.LocalPath!).ToString();
-                            yield return detail;
+                        } catch (SecurityException) {
+                            detail = new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown };
                         }
+                        yield return detail;
                     }
                 }
             }
         }
         public IEnumerable<StatusDetail> GetStatusInternalGroove() {
-            const string subkeyString = @"Software\Microsoft\Office";
-            using RegistryKey key = Registry.CurrentUser.OpenSubKey(subkeyString);
-            if (key == null) {
-                yield return new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown, ServiceType = "Groove" };
-            } else {
-                if (key.SubKeyCount == 0) {
-                    yield return new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown };
-                }
-                foreach (string subkey in key.GetSubKeyNames()) {
-                    using RegistryKey userKey = key.OpenSubKey(String.Format("{0}{1}", subkey, @"\Common\Internet"));
-                    if (userKey != null && userKey.GetValue("LocalSyncClientDiskLocation") as String[] != null) {
-                        string[] folders = userKey.GetValue("LocalSyncClientDiskLocation") as String[] ?? new string[0];
-                        foreach (string folder in folders) {
-                            StatusDetail detail = new StatusDetail();
-                            try {
-                                detail.UserName = WindowsIdentity.GetCurrent().Name;
-                                detail.UserSID = UserPrincipal.Current.Sid.ToString();
-                                string[] parts = subkey.Split('!');
-                                detail.ServiceType = String.Format("Groove{0}", parts[parts.Length - 1]);
-                            } catch (Exception ex) {
-                                detail.UserName = String.Format("Groove - {0}: {1}", ex.GetType().ToString(),
-                                    ex.Message);
-                                Logging.WriteLog.WriteErrorEvent(detail.UserName);
-                            }
-                            detail.LocalPath = folder;
-                            detail.StatusString = GetStatus(detail.LocalPath).ToString();
-                            yield return detail;
-                        }
+            const string subkeyString = @"Software\Microsoft\Office"; 
+            using (RegistryKey key = Registry.CurrentUser.OpenSubKey(subkeyString)) {
+                if (key == null) {
+                    yield return new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown, ServiceType = "Groove" };
+                } else {
+                    if (key.SubKeyCount == 0) {
+                        yield return new StatusDetail() { Status = ServiceStatus.OnDemandOrUnknown };
                     }
+                    foreach (string subkey in key.GetSubKeyNames()) {
+                        using (RegistryKey userKey = key.OpenSubKey(String.Format("{0}{1}", subkey, @"\Common\Internet"))) {
+                            if (userKey != null && userKey.GetValue("LocalSyncClientDiskLocation") as String[] != null) {
+                                string[] folders = userKey.GetValue("LocalSyncClientDiskLocation") as String[] ?? new string[0];
+                                foreach (string folder in folders) {
+                                    StatusDetail detail = new StatusDetail();
+                                    try {
+                                        detail.UserName = WindowsIdentity.GetCurrent().Name;
+                                        detail.UserSID = UserPrincipal.Current.Sid.ToString();
+                                        string[] parts = subkey.Split('!');
+                                        detail.ServiceType = String.Format("Groove{0}", parts[parts.Length - 1]);
+                                    } catch (Exception ex) {
+                                        detail.UserName = String.Format("Groove - {0}: {1}", ex.GetType().ToString(),
+                                            ex.Message);
+                                        Logging.WriteLog.WriteErrorEvent(detail.UserName);
+                                    }
+                                    detail.LocalPath = folder;
+                                    detail.StatusString = GetStatus(detail.LocalPath).ToString();
+                                    yield return detail;
+                                }
+                            }
+                        }
 
+                    }
                 }
             }
         }
@@ -124,6 +137,8 @@ namespace OneDrive.OdSyncService {
                 OneDrive.UacHelper.IsProcessElevated));
             StatusDetailCollection statuses = new StatusDetailCollection();
             foreach (StatusDetail status in GetStatusInternal()) {
+                if (status.SyncRootId is null)
+                    continue;
                 uint hr = API.GetStateBySyncRootId(status.SyncRootId, out OneDriveState state);
                 if (hr == 0) {
                     status.QuotaUsedBytes = state.UsedQuota;


### PR DESCRIPTION
If other users on the computer have OneDrive enabled, and the user context running does not have access to every key in HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager\, then OdSyncStatusWS.GetStatusInternal() will throw an unhandled SecurityException.

I have moved the declaration of detail higher in the method, wrapped the dangerous code in a try/catch (with a couple reinits of detail to account for it not being redeclared in every loop), and yield return default StatusDetail() if exception is caught.

This leads, however, to API.GetStateBySyncRootId potentially being passed a null SyncRootId and throwing an invalid memory access error.  I have prevented this in two ways: GetStatusBySyncRootId now has a null check that immediately returns 1.  Addtionally, OdSyncStatusWS.GetStatus now checks for a null SyncRootId before calling GetStateBySyncRootId.